### PR TITLE
Add optional support for using RUNNER_TOKEN instead of GITHUB_PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ Or, to run a shell for debugging:
 docker run -it --entrypoint=/bin/bash quay.io/redhat-github-actions/runner:v1.0.0
 ```
 
+## Running Locally without PAT
+
+If you're not comfortable persisting a PAT with access to all of your repositories, it is also possible to manually generate a runner registration token and use that. Note that those are only good for 60 minutes, so you must keep the local files created upon registration in order to be able to restart your runner. A similar process may be especially useful in Kubernetes, so that Pods can be recreated without manual intervention.
+
+```sh
+# Create volume to persist authentication and configuration
+podman volume create runner
+# Perform registration, and copy artifacts to volume
+podman run \
+    --env RUNNER_TOKEN=$RUNNER_TOKEN \
+    --env GITHUB_OWNER=redhat-actions \
+    --env GITHUB_REPOSITORY=openshift-actions-runner \
+    --env RUNNER_LABELS="local,podman" \
+    --rm -v runner:/persistence \
+    --entrypoint='' \
+    quay.io/redhat-github-actions/runner:v1.0.0 \
+    bash -c "./register.sh && cp -rT . /persistence"
+# Run container with volume mounted over runner home directory
+podman run \               
+    --rm -v runner:/home/runner \
+    quay.io/redhat-github-actions/runner:v1.0.0
+```
+
 <a id="enterprise-support"></a>
 
 ## GitHub Enterprise Support

--- a/base/Containerfile
+++ b/base/Containerfile
@@ -41,7 +41,7 @@ RUN chown -R ${USERNAME}:0 /home/${USERNAME}/ && \
     chgrp -R 0 /home/${USERNAME}/ && \
     chmod -R g=u /home/${USERNAME}/
 
-COPY --chown=${USERNAME}:0 entrypoint.sh uid.sh ./
+COPY --chown=${USERNAME}:0 entrypoint.sh uid.sh register.sh ./
 
 USER $UID
 

--- a/base/register.sh
+++ b/base/register.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Based on https://github.com/bbrowning/github-runner/blob/master/entrypoint.sh
+
+if [ -z "${GITHUB_OWNER:-}" ]; then
+    echo "Fatal: \$GITHUB_OWNER must be set in the environment"
+    exit 1
+fi
+
+if [ -z "${GITHUB_DOMAIN:-}" ]; then
+    echo "Connecting to public GitHub"
+    GITHUB_DOMAIN="github.com"
+    GITHUB_API_SERVER="api.github.com"
+else
+    echo "Connecting to GitHub server at '$GITHUB_DOMAIN'"
+    GITHUB_API_SERVER="${GITHUB_DOMAIN}/api/v3"
+fi
+
+echo "GitHub API server is '$GITHUB_API_SERVER'"
+
+if [ -z "${GITHUB_REPOSITORY:-}" ] && [ -n "${GITHUB_REPO:-}" ]; then
+    GITHUB_REPOSITORY=$GITHUB_REPO
+fi
+
+# https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#create-a-registration-token-for-an-organization
+
+registration_url="https://${GITHUB_DOMAIN}/${GITHUB_OWNER}${GITHUB_REPOSITORY:+/$GITHUB_REPOSITORY}"
+
+if [ -z "${GITHUB_PAT:-}" ]; then
+    echo "GITHUB_PAT not set in the environment. Automatic runner removal will be disabled."
+    echo "Visit ${registration_url}/settings/actions/runners to manually force removal of runner."
+fi
+
+if [ -z "${RUNNER_TOKEN:-}" ]; then
+    if [ -z "${GITHUB_REPOSITORY:-}" ]; then
+        echo "Runner is scoped to organization '${GITHUB_OWNER}'"
+        echo "View runner status at https://${GITHUB_DOMAIN}/organizations/${GITHUB_OWNER}/settings/actions"
+
+        token_url="https://${GITHUB_API_SERVER}/orgs/${GITHUB_OWNER}/actions/runners/registration-token"
+    else
+        echo "Runner is scoped to repository '${GITHUB_OWNER}/${GITHUB_REPOSITORY}'"
+        echo "View runner status at https://${GITHUB_DOMAIN}/${GITHUB_OWNER}/${GITHUB_REPOSITORY}/settings/actions"
+
+        token_url="https://${GITHUB_API_SERVER}/repos/${GITHUB_OWNER}/${GITHUB_REPOSITORY}/actions/runners/registration-token"
+    fi
+    echo "Obtaining runner token from ${token_url}"
+
+    payload=$(curl -sSfLX POST -H "Authorization: token ${GITHUB_PAT}" ${token_url})
+    export RUNNER_TOKEN=$(echo $payload | jq .token --raw-output)
+    echo "Obtained registration token"
+else
+    echo "Using RUNNER_TOKEN from environment"
+fi
+
+labels_arg=""
+if [ -n "${RUNNER_LABELS:-}" ]; then
+    labels_arg="--labels $RUNNER_LABELS"
+else
+    echo "No labels provided"
+fi
+
+if [ -n "${RUNNER_TOKEN:-}" ]; then
+    set -x
+    ./config.sh \
+        --name $(hostname) \
+        --token ${RUNNER_TOKEN} \
+        --url ${registration_url} \
+        --work ${RUNNER_WORKDIR} \
+        ${labels_arg} \
+        --unattended \
+        --replace
+    set +x
+fi
+
+remove() {
+    payload=$(curl -sSfLX POST -H "Authorization: token ${GITHUB_PAT}" ${token_url%/registration-token}/remove-token)
+    export REMOVE_TOKEN=$(echo $payload | jq .token --raw-output)
+
+    ./config.sh remove --unattended --token "${REMOVE_TOKEN}"
+}
+


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description

Allows users to manually generate a narrowly-scoped runner registration token, rather than a long-lived PAT, with the expense of additional complexity. Existing PAT functionality is unchanged -- except that omission of GITHUB_PAT env variable is no longer fatal.

### Related Issue(s)

Resolves #9 

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
- [x] This PR's changes were tested manually
---
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

- Made $GITHUB_PAT env variable optional
- Split registration steps into separate script for optional use of an init Job in Kubernetes
- Documented persistence with a volume when not using a PAT
