### PR TITLE
Add support for the ephemeral flag

### DIFF
--- a/base/Containerfile
+++ b/base/Containerfile
@@ -28,6 +28,7 @@ ENV GITHUB_REPOSITORY ""
 ENV RUNNER_WORKDIR /home/${USERNAME}/_work
 ENV RUNNER_GROUP ""
 ENV RUNNER_LABELS ""
+ENV EPHEMERAL ""
 
 # Allow group 0 to modify these /etc/ files since on openshift, the dynamically-assigned user is always part of group 0.
 # Also see ./uid.sh for the usage of these permissions.

--- a/base/register.sh
+++ b/base/register.sh
@@ -83,6 +83,11 @@ else
     echo "No runner group provided"
 fi
 
+ephemeral_arg=""
+if [ -n "${EPHEMERAL:-}" ]; then
+    ephemeral_arg="--ephemeral"
+fi
+
 if [ -n "${RUNNER_TOKEN:-}" ]; then
     set -x
     ./config.sh \
@@ -92,6 +97,7 @@ if [ -n "${RUNNER_TOKEN:-}" ]; then
         --work ${RUNNER_WORKDIR} \
         ${labels_arg} \
         ${runner_group_arg} \
+        ${ephemeral_arg} \
         --unattended \
         --replace
     set +x


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description
This PR adds support for the `--ephemeral` flag for github action runners which tells the runner to [quit/unregister after having run one job](https://docs.github.com/en/actions/hosting-your-own-runners/autoscaling-with-self-hosted-runners#using-ephemeral-runners-for-autoscaling). This is useful as it forces the Deployment running the container to restart it and reregister it after each job (assuming a normal restartpolicy), giving each new job a clean slate much like the cloud hosted github actions runners.

Without this flag, jobs could leave state behind in non-obvious ways (like using ssh-agent) that could impact future job runs especially if the runner is used for a variety of different repositories.
<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)
No related issues
<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made
Updated the Containerfile to support the `EPHEMERAL` environment variable
Updated the register.sh script to set the `--ephemeral` flag if the corresponding environment variable is not null.
<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
