### PR TITLE
Update base to Fedora 35 and add .NET 6 runner

### DIFF
--- a/base/Containerfile
+++ b/base/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM fedora:35
 
 # Adapted from https://github.com/bbrowning/github-runner/blob/master/Dockerfile
 RUN dnf -y upgrade --security && \

--- a/base/README.md
+++ b/base/README.md
@@ -2,7 +2,7 @@
 
 [![Quay org](https://img.shields.io/badge/quay-redhat--github--actions%2Frunner-red)](https://quay.io/repository/redhat-github-actions/runner)
 
-The base actions runner is meant to be minimal. It is build from [`fedora:33`](https://hub.docker.com/_/fedora), and contains the [GitHub Actions Runner](https://github.com/actions/runner/) and all its dependencies. At image build time, the latest runner version [is downloaded](./get-runner-release.sh), and the runner self-updates when it is connected to GitHub.
+The base actions runner is meant to be minimal. It is build from [`fedora:35`](https://hub.docker.com/_/fedora), and contains the [GitHub Actions Runner](https://github.com/actions/runner/) and all its dependencies. At image build time, the latest runner version [is downloaded](./get-runner-release.sh), and the runner self-updates when it is connected to GitHub.
 
 On OpenShift, containers run as a dynamically assigned user ID You can read about this on [the OpenShift blog](https://www.openshift.com/blog/a-guide-to-openshift-and-uids). This image contains logic to assign that user ID to the `runner` user and make sure the home directory and other required files are have the necessary permissions.
 

--- a/dotnet-6.0/Containerfile
+++ b/dotnet-6.0/Containerfile
@@ -1,0 +1,8 @@
+ARG BASE_IMG=quay.io/redhat-github-actions/runner:latest
+FROM $BASE_IMG AS dotnet-6.0-runner
+
+USER root
+
+RUN dnf install dotnet-sdk-6.0
+
+USER $UID

--- a/dotnet-6.0/Containerfile
+++ b/dotnet-6.0/Containerfile
@@ -3,6 +3,6 @@ FROM $BASE_IMG AS dotnet-6.0-runner
 
 USER root
 
-RUN dnf install dotnet-sdk-6.0
+RUN dnf install -y dotnet-sdk-6.0
 
 USER $UID

--- a/dotnet-6.0/README.md
+++ b/dotnet-6.0/README.md
@@ -1,0 +1,5 @@
+# .NET 6.0 Runner
+
+This runner is the [base runner](../base/) extended to include the .NET 6.0 SDK for building .NET 6 applications.
+
+.NET 6 is only supported on Fedora 34 and higher. [More info from Microsoft](https://docs.microsoft.com/en-us/dotnet/core/install/linux-fedora)

--- a/node/Containerfile
+++ b/node/Containerfile
@@ -5,6 +5,6 @@ USER root
 
 # https://nodejs.org/en/download/package-manager/#centos-fedora-and-red-hat-enterprise-linux
 # 14 is LTS
-RUN dnf module install -y nodejs:14/default
+RUN dnf module install -y nodejs:14
 
 USER $UID


### PR DESCRIPTION
### Description

Add support for .NET 6 by upgrading Fedora and adding a new Containerfile that installs the dotnet-6.0-sdk

### Related Issue(s)

#16 

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [x] This change is a major (breaking) change

### Changes made
 - Upgrade to Fedora 35
 - New Containerfile and README for .NET 6
