### PR TITLE
Add zstd package to allow the usage of Zstandard compression

### DIFF
--- a/base/Containerfile
+++ b/base/Containerfile
@@ -3,7 +3,7 @@ FROM fedora:35
 # Adapted from https://github.com/bbrowning/github-runner/blob/master/Dockerfile
 RUN dnf -y upgrade --security && \
     dnf -y --setopt=skip_missing_names_on_install=False install \
-    curl git jq hostname procps findutils which openssl && \
+    curl git jq hostname procps findutils which openssl zstd && \
     dnf clean all
 
 # The UID env var should be used in child Containerfile.


### PR DESCRIPTION
### Description

Official GitHub runners added support for the Zstandard compressions as part of https://github.com/actions/runner-images/issues/89

Adding the `zstd` package would allow the compression algorithm to be used with OpenShift Runners as well.


### Related Issue(s)
https://github.com/actions/cache/issues/6


### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [x] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made
- Added package `zstd`

