### PR TITLE
Update base and buildah images

### DIFF
--- a/base/Containerfile
+++ b/base/Containerfile
@@ -3,7 +3,7 @@ FROM fedora:35
 # Adapted from https://github.com/bbrowning/github-runner/blob/master/Dockerfile
 RUN dnf -y upgrade --security && \
     dnf -y --setopt=skip_missing_names_on_install=False install \
-    curl git jq hostname procps findutils which openssl && \
+    curl git jq hostname procps findutils which openssl python3-pip && \
     dnf clean all
 
 # The UID env var should be used in child Containerfile.

--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -9,9 +9,11 @@ USER root
 # https://github.com/containers/buildah/issues/3053
 
 RUN dnf -y update && \
-    dnf -y install xz slirp4netns buildah podman fuse-overlayfs shadow-utils --exclude container-selinux && \
+    dnf -y install xz slirp4netns buildah podman fuse-overlayfs shadow-utils python3-pip --exclude container-selinux && \
     dnf -y reinstall shadow-utils && \
     dnf clean all
+
+RUN pip3 install podman-compose
 
 ARG OC_VERSION=4.7.4
 RUN curl -sSLf https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz \
@@ -26,6 +28,12 @@ ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahi
 RUN chgrp -R 0 /etc/containers/ && \
     chmod -R a+r /etc/containers/ && \
     chmod -R g+w /etc/containers/
+
+# podman-login
+# https://github.com/redhat-actions/podman-login/issues/18
+RUN mkdir -vp /home/$USERNAME/.docker && \
+    echo "{ \"auths\": {} }" > /home/$USERNAME/.docker/config.json && \
+    chown -Rv ${USERNAME} /home/$USERNAME/.docker
 
 # Use VFS since fuse does not work
 # https://github.com/containers/buildah/blob/master/vendor/github.com/containers/storage/storage.conf


### PR DESCRIPTION
### Description

This PR update both Base and Buildah image.  
Add python-pip by default to allow user to install some tools used in CI, like pylint. 
Add podman-compose to allow user to run compose test
Workaround to use podman-login GH action

### Related Issue(s)

https://github.com/redhat-actions/podman-login/issues/18

### Checklist

- [ ] This PR includes a documentation change
- [X] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [X] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [X] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

#### Base Image
Add python3-pip

#### Buildah Image
Add python3-pip
Add podman-compose
Fix podman-login issue

