### PR TITLE
Fix containers.conf download path

### DIFF
--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -21,7 +21,7 @@ RUN curl -sSLf https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/
 ENV BUILDAH_ISOLATION=chroot
 ENV BUILDAH_LAYERS=true
 
-ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahimage/stable/containers.conf /etc/containers/
+ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahimage/containers.conf /etc/containers/
 
 RUN chgrp -R 0 /etc/containers/ && \
     chmod -R a+r /etc/containers/ && \

--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -21,7 +21,7 @@ RUN curl -sSLf https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/
 ENV BUILDAH_ISOLATION=chroot
 ENV BUILDAH_LAYERS=true
 
-ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahimage/containers.conf /etc/containers/
+ADD https://raw.githubusercontent.com/containers/image_build/main/buildah/containers.conf /etc/containers/
 
 RUN chgrp -R 0 /etc/containers/ && \
     chmod -R a+r /etc/containers/ && \


### PR DESCRIPTION
As part of https://github.com/containers/buildah/commit/36afa3530e5b2f290455968e89a5a4c82261773b, the stable part of the file path was removed.

<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description

<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)

<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [x] This change is not user-facing
- [x] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

Adjustment of URL