### PR TITLE
Plattform-3144 bruk vault plugin for token oppdatering

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,8 +7,15 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "docker"
-    # Workflow files stored in the
-    # default location of `.github/workflows`
-    directory: "/"
+    # directories with dockerfiles
+    directories:
+      - "/base"
+      - "/buildah"
+      - "/deploy"
+      - "/dotnet-6.0"
+      - "/java"
+      - "/k8s-tools"
+      - "/node"
+      - "/playwright"
     schedule:
       interval: "weekly"

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -10,9 +10,9 @@ on:
 jobs:
   markdown-link-check:
     name: Check links in markdown
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -12,7 +12,7 @@ jobs:
     name: Check links in markdown
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -12,7 +12,7 @@ jobs:
     name: Check links in markdown
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,0 +1,39 @@
+name: Nightly build
+
+on:
+  workflow_dispatch:
+  schedule:
+    # once every day
+    - cron: '0 0 * * *'
+
+env:
+  REGISTRY_URL: ghcr.io/domstolene/openshift-actions-runners
+
+  PLAYWRIGHT_IMG_NAME: playwright-runner
+  PLAYWRIGHT_IMG_DIR: playwright
+  IMG_TAGS: latest
+
+jobs:
+  update_images:
+    name: Update images
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push playwright image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.PLAYWRIGHT_IMG_DIR }}
+          file: ${{ env.PLAYWRIGHT_IMG_DIR }}/Containerfile
+          push: true
+          tags: ${{ env.REGISTRY_URL }}/${{ env.PLAYWRIGHT_IMG_NAME }}:${{ env.IMG_TAGS }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push playwright image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.PLAYWRIGHT_IMG_DIR }}
           file: ${{ env.PLAYWRIGHT_IMG_DIR }}/Containerfile

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY_URL }}
           username: ${{ github.actor }}

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -1,12 +1,15 @@
 name: Update Runner Images
 on:
   push:
+    branches: ["main"]
   pull_request:
+  release:
+    types: [published]
   workflow_dispatch:
 
 
 env:
-  REGISTRY_URL: quay.io/redhat-github-actions
+  REGISTRY_URL: ghcr.io/domstolene/openshift-actions-runners
 
   BASE_IMG_NAME: runner
   BASE_IMG_DIR: base
@@ -26,10 +29,13 @@ env:
 jobs:
   update_images:
     name: Update images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: redhat-actions/common/commit-data@v1
         id: commit_data
@@ -124,28 +130,21 @@ jobs:
           echo "Base image is '$BASE_IMG'"
           echo BASE_IMG=$BASE_IMG >> $GITHUB_ENV
 
-      - name: Build base image
-        if: env.BASE_CHANGED == 'true'
-        uses: redhat-actions/buildah-build@v2
-        id: build_base_img
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          image: ${{ env.BASE_IMG_NAME }}
-          tags: ${{ env.IMG_TAGS }}
-          oci: true
-          context:
-            ${{ env.BASE_IMG_DIR }}
-          dockerfiles:
-            ${{ env.BASE_IMG_DIR }}/Containerfile
-
-      - name: Push base image
-        if: steps.commit_data.outputs.is_pr == 'false' && env.BASE_CHANGED == 'true'
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ env.BASE_IMG_NAME }}
-          tags: ${{ env.IMG_TAGS }}
           registry: ${{ env.REGISTRY_URL }}
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push base image
+        if: env.BASE_CHANGED == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.BASE_IMG_DIR }}
+          file: ${{ env.BASE_IMG_DIR }}/Containerfile
+          push: ${{ steps.commit_data.outputs.is_pr == 'false' }}
+          tags: ${{ env.REGISTRY_URL }}/${{ env.BASE_IMG_NAME }}${{ env.IMG_TAGS }}
 
       - name: Determine if child images should be built
         run: |
@@ -162,122 +161,50 @@ jobs:
           fi
           echo "BUILD_CHILDREN=$BUILD_CHILDREN" >> $GITHUB_ENV
 
-      - name: Build buildah image
+      - name: Build and push buildah image
         if: |
           always() &&
           env.BUILDAH_CHANGED == 'true' &&
           env.BUILD_CHILDREN == 'true'
-        id: build_buildah
-        uses: redhat-actions/buildah-build@v2
+        uses: docker/build-push-action@v6
         with:
-          image: ${{ env.BUILDAH_IMG_NAME }}
-          tags: ${{ env.IMG_TAGS }}
-          oci: true
-          context:
-            ${{ env.BUILDAH_IMG_DIR }}
-          dockerfiles:
-            ${{ env.BUILDAH_IMG_DIR }}/Containerfile
-          build-args: |
-            BASE_IMG=${{ env.BASE_IMG }}
+          context: ${{ env.BUILDAH_IMG_DIR }}
+          file: ${{ env.BUILDAH_IMG_DIR }}/Containerfile
+          push: ${{ steps.commit_data.outputs.is_pr == 'false' }}
+          tags: ${{ env.REGISTRY_URL }}/${{ env.BUILDAH_IMG_NAME }}:${{ env.IMG_TAGS }}
 
-      - name: Push buildah image
-        if: |
-          steps.build_buildah.outcome == 'success' &&
-          steps.commit_data.outputs.is_pr == 'false'
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ env.BUILDAH_IMG_NAME }}
-          tags: ${{ env.IMG_TAGS }}
-          registry: ${{ env.REGISTRY_URL }}
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Build K8s tools image
+      - name: Build and push K8s tools image
         if: |
           always() &&
           env.K8S-TOOLS_CHANGED == 'true' &&
           env.BUILD_CHILDREN == 'true'
-        uses: redhat-actions/buildah-build@v2
-        id: build_k8s
+        uses: docker/build-push-action@v6
         with:
-          image: ${{ env.K8S_TOOLS_IMG_NAME }}
-          tags: ${{ env.IMG_TAGS }}
-          oci: true
-          context:
-            ${{ env.K8S_TOOLS_IMG_DIR }}
-          dockerfiles:
-            ${{ env.K8S_TOOLS_IMG_DIR }}/Containerfile
-          build-args: |
-            BASE_IMG=${{ env.BASE_IMG }}
+          context: ${{ env.K8S_TOOLS_IMG_DIR }}
+          file: ${{ env.K8S_TOOLS_IMG_DIR }}/Containerfile
+          push: ${{ steps.commit_data.outputs.is_pr == 'false' }}
+          tags: ${{ env.REGISTRY_URL }}/${{ env.K8S_TOOLS_IMG_NAME }}:${{ env.IMG_TAGS }}
 
-      - name: Push K8s tools image
-        if: |
-          steps.build_k8s.outcome == 'success' &&
-          steps.commit_data.outputs.is_pr == 'false'
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ env.K8S_TOOLS_IMG_NAME }}
-          tags: ${{ env.IMG_TAGS }}
-          registry: ${{ env.REGISTRY_URL }}
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Build Node image
+      - name: Build and push node image
         if: |
           always() &&
           env.NODE_CHANGED == 'true' &&
           env.BUILD_CHILDREN == 'true'
-        id: build_node
-        uses: redhat-actions/buildah-build@v2
+        uses: docker/build-push-action@v6
         with:
-          image: ${{ env.NODE_IMG_NAME }}
-          tags: ${{ env.IMG_TAGS }}
-          oci: true
-          context:
-            ${{ env.NODE_IMG_DIR }}
-          dockerfiles:
-            ${{ env.NODE_IMG_DIR }}/Containerfile
-          build-args: |
-            BASE_IMG=${{ env.BASE_IMG }}
+          context: ${{ env.NODE_IMG_DIR }}
+          file: ${{ env.NODE_IMG_DIR }}/Containerfile
+          push: ${{ steps.commit_data.outputs.is_pr == 'false' }}
+          tags: ${{ env.REGISTRY_URL }}/${{ env.NODE_IMG_NAME }}:${{ env.IMG_TAGS }}
 
-      - name: Push Node image
-        if: |
-          steps.build_node.outcome == 'success' &&
-          steps.commit_data.outputs.is_pr == 'false'
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ env.NODE_IMG_NAME }}
-          tags: ${{ env.IMG_TAGS }}
-          registry: ${{ env.REGISTRY_URL }}
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Build Java image
+      - name: Build and push java image
         if: |
           always() &&
-          env.JAVA_CHANGED == 'true' &&
+          env.NODE_CHANGED == 'true' &&
           env.BUILD_CHILDREN == 'true'
-        id: build_java
-        uses: redhat-actions/buildah-build@v2
+        uses: docker/build-push-action@v6
         with:
-          image: ${{ env.JAVA_IMG_NAME }}
-          tags: ${{ env.IMG_TAGS }}
-          oci: true
-          context:
-            ${{ env.JAVA_IMG_DIR }}
-          dockerfiles:
-            ${{ env.JAVA_IMG_DIR }}/Containerfile
-          build-args: |
-            BASE_IMG=${{ env.BASE_IMG }}
-
-      - name: Push Java image
-        if: |
-          steps.build_java.outcome == 'success' &&
-          steps.commit_data.outputs.is_pr == 'false'
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ env.JAVA_IMG_NAME }}
-          tags: ${{ env.IMG_TAGS }}
-          registry: ${{ env.REGISTRY_URL }}
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          context: ${{ env.JAVA_IMG_DIR }}
+          file: ${{ env.JAVA_IMG_DIR }}/Containerfile
+          push: ${{ steps.commit_data.outputs.is_pr == 'false' }}
+          tags: ${{ env.REGISTRY_URL }}/${{ env.JAVA_IMG_DIR }}:${{ env.IMG_TAGS }}

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: redhat-actions/common/commit-data@v1
         id: commit_data
 
-      - uses: lots0logs/gh-action-get-changed-files@2.1.4
+      - uses: lots0logs/gh-action-get-changed-files@2.2.2
         id: get_changed_files
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -20,11 +20,17 @@ env:
   K8S_TOOLS_IMG_NAME: k8s-tools-runner
   K8S_TOOLS_IMG_DIR: k8s-tools
 
-  NODE_IMG_NAME: node-runner-14
+  NODE_IMG_NAME: node-runner-22
   NODE_IMG_DIR: node
 
   JAVA_IMG_NAME: java-runner-11
   JAVA_IMG_DIR: java
+
+  DEPLOY_IMG_NAME: deploy-runner
+  DEPLOY_IMG_DIR: deploy
+
+  PLAYWRIGHT_IMG_NAME: playwright-runner
+  PLAYWRIGHT_IMG_DIR: playwright
 
 jobs:
   update_images:
@@ -63,6 +69,8 @@ jobs:
               "k8s-tools": false,
               java: false,
               node: false,
+              deploy: false,
+              playwright: false,
             };
 
             Object.keys(dirsChanged).forEach((dir) => {
@@ -201,11 +209,35 @@ jobs:
       - name: Build and push java image
         if: |
           always() &&
-          env.NODE_CHANGED == 'true' &&
+          env.JAVA_CHANGED == 'true' &&
           env.BUILD_CHILDREN == 'true'
         uses: docker/build-push-action@v6
         with:
           context: ${{ env.JAVA_IMG_DIR }}
           file: ${{ env.JAVA_IMG_DIR }}/Containerfile
           push: ${{ steps.commit_data.outputs.is_pr == 'false' }}
-          tags: ${{ env.REGISTRY_URL }}/${{ env.JAVA_IMG_DIR }}:${{ env.IMG_TAGS }}
+          tags: ${{ env.REGISTRY_URL }}/${{ env.JAVA_IMG_NAME }}:${{ env.IMG_TAGS }}
+
+      - name: Build and push deploy image
+        if: |
+          always() &&
+          env.DEPLOY_CHANGED == 'true' &&
+          env.BUILD_CHILDREN == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.DEPLOY_IMG_DIR }}
+          file: ${{ env.DEPLOY_IMG_DIR }}/Containerfile
+          push: ${{ steps.commit_data.outputs.is_pr == 'false' }}
+          tags: ${{ env.REGISTRY_URL }}/${{ env.DEPLOY_IMG_NAME }}:${{ env.IMG_TAGS }}
+
+      - name: Build and push playwright image
+        if: |
+          always() &&
+          env.PLAYWRIGHT_CHANGED == 'true' &&
+          env.BUILD_CHILDREN == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.PLAYWRIGHT_IMG_DIR }}
+          file: ${{ env.PLAYWRIGHT_IMG_DIR }}/Containerfile
+          push: ${{ steps.commit_data.outputs.is_pr == 'false' }}
+          tags: ${{ env.REGISTRY_URL }}/${{ env.PLAYWRIGHT_IMG_NAME }}:${{ env.IMG_TAGS }}

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -138,13 +138,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push base image
+        id: build_base_img
         if: env.BASE_CHANGED == 'true'
         uses: docker/build-push-action@v6
         with:
           context: ${{ env.BASE_IMG_DIR }}
           file: ${{ env.BASE_IMG_DIR }}/Containerfile
           push: ${{ steps.commit_data.outputs.is_pr == 'false' }}
-          tags: ${{ env.REGISTRY_URL }}/${{ env.BASE_IMG_NAME }}${{ env.IMG_TAGS }}
+          tags: ${{ env.REGISTRY_URL }}/${{ env.BASE_IMG_NAME }}:${{ env.IMG_TAGS }}
 
       - name: Determine if child images should be built
         run: |

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -41,7 +41,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: redhat-actions/common/commit-data@v1
         id: commit_data

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Determine changed directories
         id: is_dir_changed
-        uses: actions/github-script@v4
+        uses: actions/github-script@v7
         with:
           script: |
             const changedFiles = ${{ steps.get_changed_files.outputs.all }};

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Determine changed directories
         id: is_dir_changed
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const changedFiles = ${{ steps.get_changed_files.outputs.all }};

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -41,7 +41,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: redhat-actions/common/commit-data@v1
         id: commit_data

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -54,9 +54,11 @@ jobs:
       - name: Determine changed directories
         id: is_dir_changed
         uses: actions/github-script@v8
+        env:
+          CHANGED_FILES: ${{ steps.get_changed_files.outputs.all }}
         with:
           script: |
-            const changedFiles = ${{ steps.get_changed_files.outputs.all }};
+            const changedFiles = JSON.parse(process.env.CHANGED_FILES || "[]");
             console.log(`Changed files: ${JSON.stringify(changedFiles)}`);
 
             // console.log(`payload ${JSON.stringify(context.payload)}`);

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Build and push base image
         id: build_base_img
         if: env.BASE_CHANGED == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.BASE_IMG_DIR }}
           file: ${{ env.BASE_IMG_DIR }}/Containerfile
@@ -177,7 +177,7 @@ jobs:
           always() &&
           env.BUILDAH_CHANGED == 'true' &&
           env.BUILD_CHILDREN == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.BUILDAH_IMG_DIR }}
           file: ${{ env.BUILDAH_IMG_DIR }}/Containerfile
@@ -189,7 +189,7 @@ jobs:
           always() &&
           env.K8S-TOOLS_CHANGED == 'true' &&
           env.BUILD_CHILDREN == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.K8S_TOOLS_IMG_DIR }}
           file: ${{ env.K8S_TOOLS_IMG_DIR }}/Containerfile
@@ -201,7 +201,7 @@ jobs:
           always() &&
           env.NODE_CHANGED == 'true' &&
           env.BUILD_CHILDREN == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.NODE_IMG_DIR }}
           file: ${{ env.NODE_IMG_DIR }}/Containerfile
@@ -213,7 +213,7 @@ jobs:
           always() &&
           env.JAVA_CHANGED == 'true' &&
           env.BUILD_CHILDREN == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.JAVA_IMG_DIR }}
           file: ${{ env.JAVA_IMG_DIR }}/Containerfile
@@ -225,7 +225,7 @@ jobs:
           always() &&
           env.DEPLOY_CHANGED == 'true' &&
           env.BUILD_CHILDREN == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.DEPLOY_IMG_DIR }}
           file: ${{ env.DEPLOY_IMG_DIR }}/Containerfile
@@ -237,7 +237,7 @@ jobs:
           always() &&
           env.PLAYWRIGHT_CHANGED == 'true' &&
           env.BUILD_CHILDREN == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.PLAYWRIGHT_IMG_DIR }}
           file: ${{ env.PLAYWRIGHT_IMG_DIR }}/Containerfile

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -141,7 +141,7 @@ jobs:
           echo BASE_IMG=$BASE_IMG >> $GITHUB_ENV
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY_URL }}
           username: ${{ github.actor }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @domstolene/plattformteam

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Link checker](https://github.com/domstolene/openshift-actions-runners/actions/workflows/link_check.yml/badge.svg)](https://github.com/domstolene/openshift-actions-runners/actions/workflows/link_check.yml)
 
 [![Tag](https://img.shields.io/github/v/tag/domstolene/openshift-actions-runners)](https://github.com/domstolene/openshift-actions-runners/tags)
-[![Quay org](https://img.shields.io/badge/quay-redhat--github--actions-red)](https://quay.io/organization/redhat-github-actions)
+[![Packages](https://img.shields.io/badge/ghcr.io-red)](https://github.com/orgs/domstolene/packages?repo_name=openshift-actions-runners)
 
 This repository contains Containerfiles for building container images that act as [self-hosted GitHub Action runners](https://docs.github.com/en/free-pro-team@latest/actions/hosting-your-own-runners/about-self-hosted-runners) that work on OpenShift.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # OpenShift GitHub Actions Runners
 
-[![Update Runner Images](https://github.com/redhat-actions/openshift-actions-runner/actions/workflows/update_images.yml/badge.svg)](https://github.com/redhat-actions/openshift-actions-runner/actions/workflows/update_images.yml)
-[![Link checker](https://github.com/redhat-actions/openshift-actions-runner/actions/workflows/link_check.yml/badge.svg)](https://github.com/redhat-actions/openshift-actions-runner/actions/workflows/link_check.yml)
+[![Update Runner Images](https://github.com/domstolene/openshift-actions-runners/actions/workflows/update_images.yml/badge.svg)](https://github.com/domstolene/openshift-actions-runners/actions/workflows/update_images.yml)
+[![Link checker](https://github.com/domstolene/openshift-actions-runners/actions/workflows/link_check.yml/badge.svg)](https://github.com/domstolene/openshift-actions-runners/actions/workflows/link_check.yml)
 
-[![Tag](https://img.shields.io/github/v/tag/redhat-actions/openshift-actions-runner)](https://github.com/redhat-actions/openshift-actions-runner/tags)
+[![Tag](https://img.shields.io/github/v/tag/domstolene/openshift-actions-runners)](https://github.com/domstolene/openshift-actions-runners/tags)
 [![Quay org](https://img.shields.io/badge/quay-redhat--github--actions-red)](https://quay.io/organization/redhat-github-actions)
 
 This repository contains Containerfiles for building container images that act as [self-hosted GitHub Action runners](https://docs.github.com/en/free-pro-team@latest/actions/hosting-your-own-runners/about-self-hosted-runners) that work on OpenShift.
@@ -39,11 +39,11 @@ See the [base image README](./base/#own-image).
 ## Running Locally
 You can run the images locally to test and develop.
 
-To launch and connect a runner to `redhat-actions/openshift-actions-runner` with the labels `local` and `podman`:
+To launch and connect a runner to `domstolene/openshift-actions-runner` with the labels `local` and `podman`:
 ```sh
 podman run \
     --env GITHUB_PAT=$GITHUB_PAT \
-    --env GITHUB_OWNER=redhat-actions \
+    --env GITHUB_OWNER=domstolene \
     --env GITHUB_REPOSITORY=openshift-actions-runner \
     --env RUNNER_LABELS="local,podman" \
     quay.io/redhat-github-actions/runner:latest
@@ -94,7 +94,7 @@ If the containers crash on startup, it is usually because one of the environment
 - If the container crashes with an HTTP 404 error, the `GITHUB_OWNER` or `GITHUB_REPOSITORY` is incorrect or misspelled.
     - This will also happen if a private repository is selected which the `GITHUB_PAT` does not have permission to view.
 
-If you encounter any other issues, please [open an issue](https://github.com/redhat-actions/openshift-actions-runner/issues) and we will help you work through it.
+If you encounter any other issues, please [open an issue](https://github.com/domstolene/openshift-actions-runners/issues) and we will help you work through it.
 
 ## Credits
 This repository builds on the work done in [bbrowning/github-runner](https://github.com/bbrowning/github-runner), which is forked from [SanderKnape/github-runner](https://github.com/SanderKnape/github-runner).

--- a/base/Containerfile
+++ b/base/Containerfile
@@ -1,8 +1,8 @@
-FROM fedora:35
+FROM fedora:41
 
 # Adapted from https://github.com/bbrowning/github-runner/blob/master/Dockerfile
 RUN dnf -y upgrade --security && \
-    dnf -y --setopt=skip_missing_names_on_install=False install \
+    dnf -y install \
     curl git jq hostname procps findutils which openssl && \
     dnf clean all
 

--- a/base/Containerfile
+++ b/base/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:41
+FROM fedora:43
 
 # Adapted from https://github.com/bbrowning/github-runner/blob/master/Dockerfile
 RUN dnf -y upgrade --security && \

--- a/base/README.md
+++ b/base/README.md
@@ -44,3 +44,7 @@ USER $UID
 ```
 
 Just like that, we have created the [Node runner image](../node/).
+
+### Adjustments
+
+The token for registering and unregistering with Github can now be set via a Vault plugin and the Vault Agent Injector if desired.  

--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -7,19 +7,24 @@ set -eE
 
 CREDS_FILE="${PWD}/.credentials"
 
+# Returns true if any form of PAT authentication is available
+has_github_pat() {
+    [ -f "/vault/secrets/github-pat" ] || [ -n "${GITHUB_PAT:-}" ]
+}
+
 # Assume registration artifacts have been persisted from a previous start
 # if no PAT or TOKEN is provided, and simply attempt to start.
-if [ -n "${GITHUB_PAT:-}" ] || [ -n "${RUNNER_TOKEN:-}" ] || [ -n "${GITHUB_APP_ID:-}" ]; then
+if has_github_pat || [ -n "${RUNNER_TOKEN:-}" ] || [ -n "${GITHUB_APP_ID:-}" ]; then
     source ./register.sh
 elif [ -e "${CREDS_FILE}" ]; then
-    echo "No GITHUB_PAT or RUNNER_TOKEN provided. Using existing credentials file ${CREDS_FILE}."
+    echo "No GITHUB_PAT, Vault-injected token, or RUNNER_TOKEN provided. Using existing credentials file ${CREDS_FILE}."
 else
     echo "No saved credentials found in ${CREDS_FILE}."
-    echo "Fatal: GITHUB_PAT or RUNNER_TOKEN must be set in the environment."
+    echo "Fatal: GITHUB_PAT, /vault/secrets/github-pat, or RUNNER_TOKEN must be set in the environment."
     exit 1
 fi
 
-if [ -n "${GITHUB_PAT:-}" ]; then
+if has_github_pat; then
     trap 'remove; exit 130' INT
     trap 'remove; exit 143' TERM
 elif [ -n "${GITHUB_APP_ID:-}" ]; then

--- a/base/register.sh
+++ b/base/register.sh
@@ -6,6 +6,23 @@ set -eE
 # Load Github app authentication helper function
 source ./get_github_app_token.sh
 
+# Returns a GitHub PAT either from the Vault-injected file or the environment variable
+github_pat() {
+    if [ -f "/vault/secrets/github-pat" ]; then
+        cat /vault/secrets/github-pat
+    elif [ -n "${GITHUB_PAT:-}" ]; then
+        echo "${GITHUB_PAT}"
+    else
+        echo "Fatal: No GitHub PAT available. Set GITHUB_PAT or inject via Vault to /vault/secrets/github-pat" >&2
+        exit 1
+    fi
+}
+
+# Returns true if any form of PAT authentication is available
+has_github_pat() {
+    [ -f "/vault/secrets/github-pat" ] || [ -n "${GITHUB_PAT:-}" ]
+}
+
 if [ -z "${GITHUB_OWNER:-}" ]; then
     echo "Fatal: \$GITHUB_OWNER must be set in the environment"
     exit 1
@@ -30,7 +47,7 @@ fi
 
 registration_url="https://${GITHUB_DOMAIN}/${GITHUB_OWNER}${GITHUB_REPOSITORY:+/$GITHUB_REPOSITORY}"
 
-if [ -z "${GITHUB_PAT:-}" ] && [ -z "${GITHUB_APP_ID:-}" ]; then
+if ! has_github_pat && [ -z "${GITHUB_APP_ID:-}" ]; then
     echo "Neither GITHUB_PAT nor the GITHUB_APP variables are set in the environment. Automatic runner removal will be disabled."
     echo "Visit ${registration_url}/settings/actions/runners to manually force removal of runner."
 fi
@@ -55,7 +72,7 @@ if [ -z "${RUNNER_TOKEN:-}" ]; then
         payload=$(curl -sSfLX POST -H "Authorization: token ${app_token}" ${token_url})
     else
         echo "Using GITHUB_PAT for authentication."
-        payload=$(curl -sSfLX POST -H "Authorization: token ${GITHUB_PAT}" ${token_url})
+        payload=$(curl -sSfLX POST -H "Authorization: token $(github_pat)" ${token_url})
     fi
 
     export RUNNER_TOKEN=$(echo $payload | jq .token --raw-output)
@@ -104,7 +121,7 @@ if [ -n "${RUNNER_TOKEN:-}" ]; then
 fi
 
 remove() {
-    payload=$(curl -sSfLX POST -H "Authorization: token ${GITHUB_PAT}" ${token_url%/registration-token}/remove-token)
+    payload=$(curl -sSfLX POST -H "Authorization: token $(github_pat)" ${token_url%/registration-token}/remove-token)
     export REMOVE_TOKEN=$(echo $payload | jq .token --raw-output)
 
     ./config.sh remove --unattended --token "${REMOVE_TOKEN}"

--- a/build-images.sh
+++ b/build-images.sh
@@ -3,7 +3,7 @@
 set -eEu -o pipefail
 
 # Replace with your username. Don't push your dev images to redhat-github-actions.
-REGISTRY=${RUNNERS_REGISTRY:-quay.io/tetchell}
+REGISTRY=${RUNNERS_REGISTRY:-ghcr.io/domstolene/openshift-actions-runners}
 TAG=${RUNNERS_TAG:-latest}
 
 BASE_IMG=${REGISTRY}/runner:${TAG}

--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=quay.io/redhat-github-actions/runner:latest
+ARG BASE_IMG=ghcr.io/domstolene/redhat-github-actions/runner:latest
 FROM $BASE_IMG AS buildah-runner
 
 USER root
@@ -21,7 +21,7 @@ RUN curl -sSLf https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/
 ENV BUILDAH_ISOLATION=chroot
 ENV BUILDAH_LAYERS=true
 
-ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahimage/stable/containers.conf /etc/containers/
+RUN curl https:///raw.githubusercontent.com/containers/image_build/main/buildah/containers.conf --output-dir /etc/containers/
 
 RUN chgrp -R 0 /etc/containers/ && \
     chmod -R a+r /etc/containers/ && \

--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/domstolene/redhat-github-actions/runner:latest
+ARG BASE_IMG=ghcr.io/domstolene/openshift-actions-runners/runner:latest
 FROM $BASE_IMG AS buildah-runner
 
 USER root

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -14,6 +14,7 @@ RUN dnf -y upgrade --security && \
     samba-client \
     wget \
     unzip \
+    gettext-envsubst \
     java-17-openjdk-devel && \
     dnf clean all
 

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -1,0 +1,27 @@
+ARG BASE_IMG=ghcr.io/domstolene/openshift-actions-runners/runner:latest
+FROM $BASE_IMG AS runner
+
+USER root
+
+ARG KUBERNETES_RELEASE=v1.30.4
+RUN curl -LO https://dl.k8s.io/release/${KUBERNETES_RELEASE}/bin/linux/amd64/kubectl
+RUN sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+RUN dnf -y upgrade --security && \
+    dnf -y install \
+    openldap-clients \
+    iputils \
+    samba-client \
+    wget \
+    unzip \
+    java-17-openjdk-devel && \
+    dnf clean all
+
+RUN curl -LO https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+RUN tar xzf apache-maven-3.9.9-bin.tar.gz -C /opt
+ENV JAVA_HOME=/usr/lib/jvm/java
+RUN sudo ln -s /opt/apache-maven-3.9.9/bin/mvn /usr/local/bin/mvn
+RUN mvn -version
+
+RUN sudo chmod 4711 /usr/bin/ping
+USER $UID

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -15,7 +15,7 @@ RUN dnf -y upgrade --security && \
     wget \
     unzip \
     gettext-envsubst \
-    java-17-openjdk-devel && \
+    java-21-openjdk-devel && \
     dnf clean all
 
 RUN curl -LO https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -3,7 +3,7 @@ FROM $BASE_IMG AS runner
 
 USER root
 
-ARG KUBERNETES_RELEASE=v1.30.4
+ARG KUBERNETES_RELEASE=v1.34.2
 RUN curl -LO https://dl.k8s.io/release/${KUBERNETES_RELEASE}/bin/linux/amd64/kubectl
 RUN sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
@@ -18,10 +18,10 @@ RUN dnf -y upgrade --security && \
     java-17-openjdk-devel && \
     dnf clean all
 
-RUN curl -LO https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
-RUN tar xzf apache-maven-3.9.9-bin.tar.gz -C /opt
+RUN curl -LO https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
+RUN tar xzf apache-maven-3.9.11-bin.tar.gz -C /opt
 ENV JAVA_HOME=/usr/lib/jvm/java
-RUN sudo ln -s /opt/apache-maven-3.9.9/bin/mvn /usr/local/bin/mvn
+RUN sudo ln -s /opt/apache-maven-3.9.11/bin/mvn /usr/local/bin/mvn
 RUN mvn -version
 
 RUN sudo chmod 4711 /usr/bin/ping

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -15,13 +15,14 @@ RUN dnf -y upgrade --security && \
     wget \
     unzip \
     gettext-envsubst \
-    java-21-openjdk-devel && \
+    java-21-openjdk-devel \
+    python3-winrm && \
     dnf clean all
 
-RUN curl -LO https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
-RUN tar xzf apache-maven-3.9.11-bin.tar.gz -C /opt
+RUN curl -LO https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz
+RUN tar xzf apache-maven-3.9.14-bin.tar.gz -C /opt
 ENV JAVA_HOME=/usr/lib/jvm/java
-RUN sudo ln -s /opt/apache-maven-3.9.11/bin/mvn /usr/local/bin/mvn
+RUN sudo ln -s /opt/apache-maven-3.9.14/bin/mvn /usr/local/bin/mvn
 RUN mvn -version
 
 RUN sudo chmod 4711 /usr/bin/ping

--- a/dotnet-6.0/Containerfile
+++ b/dotnet-6.0/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=quay.io/redhat-github-actions/runner:latest
+ARG BASE_IMG=ghcr.io/domstolene/redhat-github-actions/runner:latest
 FROM $BASE_IMG AS dotnet-6.0-runner
 
 USER root

--- a/dotnet-6.0/Containerfile
+++ b/dotnet-6.0/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/domstolene/redhat-github-actions/runner:latest
+ARG BASE_IMG=ghcr.io/domstolene/openshift-actions-runners/runner:latest
 FROM $BASE_IMG AS dotnet-6.0-runner
 
 USER root

--- a/java/Containerfile
+++ b/java/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/domstolene/redhat-github-actions/runner:latest
+ARG BASE_IMG=ghcr.io/domstolene/openshift-actions-runners/runner:latest
 FROM $BASE_IMG AS java-runner
 
 USER root

--- a/java/Containerfile
+++ b/java/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=quay.io/redhat-github-actions/runner:latest
+ARG BASE_IMG=ghcr.io/domstolene/redhat-github-actions/runner:latest
 FROM $BASE_IMG AS java-runner
 
 USER root

--- a/java/Containerfile
+++ b/java/Containerfile
@@ -3,6 +3,6 @@ FROM $BASE_IMG AS java-runner
 
 USER root
 
-RUN dnf install -y java-11-openjdk-devel.x86_64
+RUN dnf install -y java-21-openjdk-devel.x86_64
 
 USER $UID

--- a/k8s-tools/Containerfile
+++ b/k8s-tools/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/domstolene/redhat-github-actions/runner:latest
+ARG BASE_IMG=ghcr.io/domstolene/openshift-actions-runners/runner:latest
 FROM $BASE_IMG AS k8s-tools-runner
 
 USER root

--- a/k8s-tools/Containerfile
+++ b/k8s-tools/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=quay.io/redhat-github-actions/runner:latest
+ARG BASE_IMG=ghcr.io/domstolene/redhat-github-actions/runner:latest
 FROM $BASE_IMG AS k8s-tools-runner
 
 USER root

--- a/node/Containerfile
+++ b/node/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/domstolene/redhat-github-actions/runner:latest
+ARG BASE_IMG=ghcr.io/domstolene/openshift-actions-runners/runner:latest
 FROM $BASE_IMG AS node-runner
 
 USER root

--- a/node/Containerfile
+++ b/node/Containerfile
@@ -1,10 +1,10 @@
-ARG BASE_IMG=quay.io/redhat-github-actions/runner:latest
+ARG BASE_IMG=ghcr.io/domstolene/redhat-github-actions/runner:latest
 FROM $BASE_IMG AS node-runner
 
 USER root
 
 # https://nodejs.org/en/download/package-manager/#centos-fedora-and-red-hat-enterprise-linux
-# 14 is LTS
-RUN dnf module install -y nodejs:14
+# 22 is LTS
+RUN dnf install nodejs -y
 
 USER $UID

--- a/playwright/Containerfile
+++ b/playwright/Containerfile
@@ -15,7 +15,7 @@ RUN dnf install -y \
     liberation-fonts libappindicator-gtk3 alsa-lib at-spi2-atk at-spi2-core \
     cairo cups-libs dbus-libs expat fontconfig glib2 nspr nss libpng libX11 \
     libxcb libXcomposite libXcursor libXdamage libXext libXfixes libXi \
-    libXrandr libXrender libXtst wget xdg-utils && \
+    libXrandr libXrender libXtst wget xdg-utils gettext-envsubst && \
     dnf clean all
 
 # Install Playwright

--- a/playwright/Containerfile
+++ b/playwright/Containerfile
@@ -1,0 +1,40 @@
+ARG BASE_IMG=ghcr.io/domstolene/openshift-actions-runners/runner:latest
+FROM $BASE_IMG AS runner
+
+# Switch to root user to install dependencies
+USER root
+
+# Install Node.js and npm
+RUN dnf install -y nodejs npm
+
+# Install system dependencies
+RUN dnf install -y \
+    atk cups-libs gtk3 ipa-gothic-fonts libXcomposite libXcursor libXdamage \
+    libXext libXi libXrandr libXScrnSaver libXtst pango at-spi2-atk libXt \
+    xorg-x11-server-Xvfb libdrm libgbm alsa-lib chromium firefox webkit2gtk3 \
+    liberation-fonts libappindicator-gtk3 alsa-lib at-spi2-atk at-spi2-core \
+    cairo cups-libs dbus-libs expat fontconfig glib2 nspr nss libpng libX11 \
+    libxcb libXcomposite libXcursor libXdamage libXext libXfixes libXi \
+    libXrandr libXrender libXtst wget xdg-utils && \
+    dnf clean all
+
+# Install Playwright
+RUN npm init -y && \
+    npm install -g playwright
+
+# Set up Playwright browsers directory with correct permissions
+RUN mkdir -p /ms-playwright && \
+    chown -R 1001:1001 /ms-playwright && \
+    chmod -R 755 /ms-playwright
+
+# Switch to the default user for installing browsers
+USER 1001
+
+# Download and install Playwright browsers
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+# Kjører kun chromium i CI, men kunne installert firefox og webkit dersom vi ser
+# det blir mye feil på kryss av nettlesere.
+RUN npx playwright install chromium
+
+# Set the entry point to the entrypoint.sh script
+ENTRYPOINT ["/home/runner/entrypoint.sh"]

--- a/playwright/Containerfile
+++ b/playwright/Containerfile
@@ -23,7 +23,7 @@ RUN dnf install -y \
 
 # Install Playwright
 RUN npm init -y && \
-    npm install -g playwright
+    npm install -g playwright@1
 
 # Set up Playwright browsers directory with correct permissions
 RUN mkdir -p /ms-playwright && \

--- a/playwright/Containerfile
+++ b/playwright/Containerfile
@@ -6,7 +6,7 @@ USER root
 
 # update nodesources ref: https://github.com/nodesource/distributions/issues/1747
 RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -
-    
+
 # Install Node.js and npm
 RUN dnf install -y nodejs npm
 
@@ -18,7 +18,7 @@ RUN dnf install -y \
     liberation-fonts libappindicator-gtk3 alsa-lib at-spi2-atk at-spi2-core \
     cairo cups-libs dbus-libs expat fontconfig glib2 nspr nss libpng libX11 \
     libxcb libXcomposite libXcursor libXdamage libXext libXfixes libXi \
-    libXrandr libXrender libXtst wget xdg-utils gettext-envsubst && \
+    libXrandr libXrender libXtst wget xdg-utils gettext-envsubst yq && \
     dnf clean all
 
 # Install Playwright

--- a/playwright/Containerfile
+++ b/playwright/Containerfile
@@ -4,6 +4,9 @@ FROM $BASE_IMG AS runner
 # Switch to root user to install dependencies
 USER root
 
+# update nodesources ref: https://github.com/nodesource/distributions/issues/1747
+RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -
+    
 # Install Node.js and npm
 RUN dnf install -y nodejs npm
 

--- a/playwright/Containerfile
+++ b/playwright/Containerfile
@@ -14,7 +14,7 @@ RUN dnf install -y nodejs npm
 RUN dnf install -y \
     atk cups-libs gtk3 ipa-gothic-fonts libXcomposite libXcursor libXdamage \
     libXext libXi libXrandr libXScrnSaver libXtst pango at-spi2-atk libXt \
-    xorg-x11-server-Xvfb libdrm libgbm alsa-lib chromium firefox webkit2gtk3 \
+    xorg-x11-server-Xvfb libdrm libgbm alsa-lib chromium firefox webkit2gtk4.1 \
     liberation-fonts libappindicator-gtk3 alsa-lib at-spi2-atk at-spi2-core \
     cairo cups-libs dbus-libs expat fontconfig glib2 nspr nss libpng libX11 \
     libxcb libXcomposite libXcursor libXdamage libXext libXfixes libXi \


### PR DESCRIPTION
Legger på en mulighet å bruke en short-lived token via en Github App, en Vault Plugin og Vault Agent Injector.
Det skal ikke endres noe av nåværende funksjonalitet.