### PR TITLE
Add zstd to base runner image

### DIFF
--- a/base/Containerfile
+++ b/base/Containerfile
@@ -3,7 +3,7 @@ FROM fedora:44
 # Adapted from https://github.com/bbrowning/github-runner/blob/master/Dockerfile
 RUN dnf -y upgrade --security && \
     dnf -y install \
-    curl git jq hostname procps findutils which openssl && \
+    curl git jq hostname procps findutils which openssl zstd && \
     dnf clean all
 
 # The UID env var should be used in child Containerfile.


### PR DESCRIPTION
## Summary

- Add `zstd` package to the base runner image for Zstandard compression support
- GitHub-hosted runners include `zstd`, which is used by `actions/cache` and other actions -- adding it ensures parity for self-hosted runners on OpenShift
- Supersedes #24 (which could no longer merge cleanly after the Fedora 44 / dnf5 modernization in #41)

## Test plan

- [ ] Verify base image builds successfully in CI
- [ ] Verify child images (buildah, k8s-tools, node, java) still build on top of the updated base

🤖 Generated with [Claude Code](https://claude.com/claude-code)