### PR TITLE
Fix GHE compatibility: Content-Length header and custom CA certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ and use the GitHub API at
 https://github.mycompany.com/api/v3/
 ```
 
+### Custom CA Certificates
+If your GitHub Enterprise server uses a self-signed certificate, set the `CUSTOM_CA_CERT` environment variable to the path of your CA certificate file inside the container. This configures both `curl` (for runner registration) and Node.js (for the runner process) to trust the certificate.
+
+```sh
+podman run \
+    --env GITHUB_PAT=$GITHUB_PAT \
+    --env GITHUB_OWNER=myorg \
+    --env GITHUB_DOMAIN=github.mycompany.com \
+    --env CUSTOM_CA_CERT=/certs/ca.crt \
+    -v /path/to/ca.crt:/certs/ca.crt:ro \
+    quay.io/redhat-github-actions/runner:latest
+```
+
 ## Troubleshooting
 If the containers crash on startup, it is usually because one of the environment variables is missing or misconfigured. Make sure to read the container logs carefully to make sure the variables' values are set as expected.
 

--- a/base/Containerfile
+++ b/base/Containerfile
@@ -29,6 +29,8 @@ ENV RUNNER_WORKDIR /home/${USERNAME}/_work
 ENV RUNNER_GROUP ""
 ENV RUNNER_LABELS ""
 ENV EPHEMERAL ""
+# Path to a custom CA certificate file for GitHub Enterprise with self-signed certs
+ENV CUSTOM_CA_CERT ""
 
 # Allow group 0 to modify these /etc/ files since on openshift, the dynamically-assigned user is always part of group 0.
 # Also see ./uid.sh for the usage of these permissions.

--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -5,6 +5,17 @@
 
 set -eE
 
+# If a custom CA certificate is provided, configure Node.js to trust it.
+# This is needed for GitHub Enterprise servers with self-signed certificates.
+if [ -n "${CUSTOM_CA_CERT:-}" ]; then
+    if [ -f "${CUSTOM_CA_CERT}" ]; then
+        echo "Configuring Node.js to trust custom CA certificate: ${CUSTOM_CA_CERT}"
+        export NODE_EXTRA_CA_CERTS="${CUSTOM_CA_CERT}"
+    else
+        echo "Warning: CUSTOM_CA_CERT is set to '${CUSTOM_CA_CERT}' but the file does not exist."
+    fi
+fi
+
 CREDS_FILE="${PWD}/.credentials"
 
 # Assume registration artifacts have been persisted from a previous start

--- a/base/register.sh
+++ b/base/register.sh
@@ -22,6 +22,13 @@ fi
 
 echo "GitHub API server is '$GITHUB_API_SERVER'"
 
+# Build common curl options
+CURL_OPTS="-sSfL"
+if [ -n "${CUSTOM_CA_CERT:-}" ]; then
+    echo "Using custom CA certificate from \$CUSTOM_CA_CERT"
+    CURL_OPTS="${CURL_OPTS} --cacert ${CUSTOM_CA_CERT}"
+fi
+
 if [ -z "${GITHUB_REPOSITORY:-}" ] && [ -n "${GITHUB_REPO:-}" ]; then
     GITHUB_REPOSITORY=$GITHUB_REPO
 fi
@@ -52,10 +59,10 @@ if [ -z "${RUNNER_TOKEN:-}" ]; then
     if [ -n "${GITHUB_APP_ID:-}" ] && [ -n "${GITHUB_APP_INSTALL_ID:-}" ] && [ -n "${GITHUB_APP_PEM:-}" ]; then
         echo "GITHUB_APP environment variables are set. Using GitHub App authentication."
         app_token=$(get_github_app_token)
-        payload=$(curl -sSfLX POST -H "Authorization: token ${app_token}" ${token_url})
+        payload=$(curl ${CURL_OPTS} -X POST -H "Authorization: token ${app_token}" -H "Content-Length: 0" ${token_url})
     else
         echo "Using GITHUB_PAT for authentication."
-        payload=$(curl -sSfLX POST -H "Authorization: token ${GITHUB_PAT}" ${token_url})
+        payload=$(curl ${CURL_OPTS} -X POST -H "Authorization: token ${GITHUB_PAT}" -H "Content-Length: 0" ${token_url})
     fi
 
     export RUNNER_TOKEN=$(echo $payload | jq .token --raw-output)
@@ -104,7 +111,7 @@ if [ -n "${RUNNER_TOKEN:-}" ]; then
 fi
 
 remove() {
-    payload=$(curl -sSfLX POST -H "Authorization: token ${GITHUB_PAT}" ${token_url%/registration-token}/remove-token)
+    payload=$(curl ${CURL_OPTS} -X POST -H "Authorization: token ${GITHUB_PAT}" -H "Content-Length: 0" ${token_url%/registration-token}/remove-token)
     export REMOVE_TOKEN=$(echo $payload | jq .token --raw-output)
 
     ./config.sh remove --unattended --token "${REMOVE_TOKEN}"
@@ -112,7 +119,7 @@ remove() {
 
 remove_github_app() {
     app_token=$(get_github_app_token)
-    payload=$(curl -sSfLX POST -H "Authorization: token ${app_token}" ${token_url%/registration-token}/remove-token)
+    payload=$(curl ${CURL_OPTS} -X POST -H "Authorization: token ${app_token}" -H "Content-Length: 0" ${token_url%/registration-token}/remove-token)
     export REMOVE_TOKEN=$(echo $payload | jq .token --raw-output)
 
     ./config.sh remove --unattended --token "${REMOVE_TOKEN}"


### PR DESCRIPTION
## Summary

- Add `Content-Length: 0` header to all POST curl requests in `register.sh` to fix HTTP 411 errors on GitHub Enterprise servers behind proxies that require this header
- Add `CUSTOM_CA_CERT` environment variable for GitHub Enterprise servers using self-signed certificates -- configures both `curl` (via `--cacert`) and Node.js (via `NODE_EXTRA_CA_CERTS`)
- Consolidate curl options into a `CURL_OPTS` variable for consistency
- Document custom CA certificate usage in the README

Fixes #15, fixes #20.

## Test plan

- [ ] Verify base image builds successfully
- [ ] Verify child images build on top of updated base
- [ ] Verify runner registration still works on public GitHub (no regression from Content-Length header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)