### PR TITLE
docs: add deprecation notice recommending Actions Runner Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+> **This project is no longer actively maintained.**
+>
+> We recommend migrating to [Actions Runner Controller (ARC)](https://github.com/actions/actions-runner-controller),
+> the official self-hosted runner solution maintained by GitHub. ARC provides
+> Kubernetes-native autoscaling, scale-to-zero, and active maintenance from
+> the GitHub community.
+>
+> For more information, see the
+> [official documentation](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller).
+>
+> The existing container images in this repository remain available for current
+> deployments, but they will not receive new features or regular updates.
+
 # OpenShift GitHub Actions Runners
 
 [![Update Runner Images](https://github.com/redhat-actions/openshift-actions-runners/actions/workflows/update_images.yml/badge.svg)](https://github.com/redhat-actions/openshift-actions-runners/actions/workflows/update_images.yml)


### PR DESCRIPTION
## Summary

- Adds a prominent deprecation notice at the top of README.md recommending migration to [Actions Runner Controller (ARC)](https://github.com/actions/actions-runner-controller)
- Links to both the ARC repository and the [official GitHub documentation](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller)
- Notes that existing container images remain available but will not receive new features or regular updates
- No existing content was removed or modified

## Test plan

- [ ] Verify the deprecation notice renders correctly as a blockquote at the top of README.md
- [ ] Verify all links in the notice resolve correctly
- [ ] Verify no existing content was changed

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>